### PR TITLE
Fix openfile navigation jumping to wrong line

### DIFF
--- a/src/cqtreedataprov.ts
+++ b/src/cqtreedataprov.ts
@@ -38,9 +38,10 @@ export default class CQResultsProvider implements vscode.TreeDataProvider<SResul
 			}
 			vscode.workspace.openTextDocument(fileuri).then(doc => {
 				vscode.window.showTextDocument(doc).then(editor => {
-					var linenum1 = parseInt(linenum, 10);
-					var remaining = editor.document.lineCount - linenum1;
-					editor.revealRange(this.calcRange(linenum1, remaining));
+					var linenum1 = parseInt(linenum, 10) - 1;
+					var pos = new vscode.Position(linenum1, 0);
+					editor.selection = new vscode.Selection(pos, pos);
+					editor.revealRange(new vscode.Range(pos, pos), vscode.TextEditorRevealType.InCenter);
 				});
 			  });
 		}


### PR DESCRIPTION
When clicking a search result, the cursor was landing on the wrong 
line, typically 20-30 lines away from the correct position.

Two bugs were fixed in the openfile() method of cqtreedataprov.ts:

1. vscode.Position uses 0-based line numbers but cqsearch returns
   1-based line numbers, so 1 is now subtracted from the line number.

2. editor.selection was never set, so the cursor never actually moved.
   It stayed at its previous position while revealRange() only scrolled
   the viewport, giving the appearance of a large random offset.

Tested on Linux (Debian 13).